### PR TITLE
Update closed loop server with new interface

### DIFF
--- a/nerfstudio/scripts/closed_loop/main.py
+++ b/nerfstudio/scripts/closed_loop/main.py
@@ -51,8 +51,8 @@ def update_actors(actor_trajectories: list[ActorTrajectory]) -> None:
     cl_server.update_actor_trajectories(torch_actor_trajectories)
 
 
-@app.get(
-    "/image",
+@app.post(
+    "/render_image",
     response_class=Response,
     responses={200: {"content": {"text/plain": {}, "image/png": {}, "image/jpeg": {}}}},
 )

--- a/nerfstudio/scripts/closed_loop/models.py
+++ b/nerfstudio/scripts/closed_loop/models.py
@@ -13,11 +13,19 @@
 # limitations under the License.
 from __future__ import annotations
 
+from enum import Enum
 from typing import List, TypedDict
 
 import torch
 from pydantic import BaseModel
 from torch import Tensor
+
+
+class ImageFormat(str, Enum):
+    raw = "raw"  # will return a raw tensor, works good when sending across same machine
+    png = "png"  # more suitable if sent over network
+    jpg = "jpg"  # more suitable if sent over network, pseudo for jpeg
+    jpeg = "jpeg"  # more suitable if sent over network
 
 
 class TrajectoryDict(TypedDict):
@@ -66,3 +74,5 @@ class RenderInput(BaseModel):
     """Timestamp in microseconds"""
     camera_name: str
     """Camera name"""
+    image_format: ImageFormat = ImageFormat.raw
+    """What format to return the image in. Defaults to raw tensor."""


### PR DESCRIPTION
Update the closed-loop server

- Removing `async` definitions 
- Serialize tensor directly instead of converting to PNG :zap: 