### PR TITLE
Fix the problem with tyro

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "awscli>=1.31.10",
     "comet_ml>=3.33.8",
     "cryptography>=38",
-    "tyro>=0.6.6",
+    "tyro==0.6.6",
     "gdown>=4.6.0",
     "ninja>=1.10",
     "h5py>=2.9.0",


### PR DESCRIPTION
Hi,  
It seems that using last version of Tyro results in an error while installing Neurad Studio: 
```
AssertionError: could not match default value (0.01, 0.01, 0.001) with any types in union                     
11.32            [<class 'float'>, <class 'tuple'>]
```
Setting tyro version 0.6.6 will resolve the problem, but I believe that [this commit](https://github.com/nerfstudio-project/nerfstudio/commit/1dc2ebd9dc1b552b1952f62dab2cedd34308e7bb) from the original Nerf Studio repository will provide a more long-term solution.