### PR TITLE
Fix checkpoint saving bug

### DIFF
--- a/nerfstudio/engine/trainer.py
+++ b/nerfstudio/engine/trainer.py
@@ -506,7 +506,7 @@ class Trainer:
         # possibly make the checkpoint directory
         if not self.checkpoint_dir.exists():
             self.checkpoint_dir.mkdir(parents=True, exist_ok=True)
-        if self.checkpoint_saving_tracker.did_degrade(fallback=True):
+        if self.checkpoint_saving_tracker.did_degrade():
             return
         self.checkpoint_saving_tracker.reset_latest()  # we only want to save the best once
         # save the checkpoint


### PR DESCRIPTION
Fixes a bug where checkpoints are not saved unless a metric tracker is enabled, since the check defaults to True (meaning metrics did degrade, and we should not save).